### PR TITLE
[주원] : Ch 7 실습

### DIFF
--- a/juwon/core/build.gradle
+++ b/juwon/core/build.gradle
@@ -8,6 +8,14 @@ group = 'hello'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+//lombok 설정 추가 시작
+configurations{
+	complieOnly{
+		extendsFrom annotationProcessor
+	}
+}
+//lombok 설정 추가 끝
+
 repositories {
 	mavenCentral()
 }

--- a/juwon/core/src/main/java/hello/core/AutoAppConfig.java
+++ b/juwon/core/src/main/java/hello/core/AutoAppConfig.java
@@ -11,8 +11,20 @@ import static org.springframework.context.annotation.ComponentScan.*;
 
 public class AutoAppConfig {
 
+
+
+    /**
+    @Bean
+    OrderService orderService(MemberRepository memberRepoisitory, DiscountPolicy
+            discountPolicy) {
+        new OrderServiceImpl(memberRepository, discountPolicy)
+    }
+     */
+
+    /**
     @Bean(name = "memoryMemberRepository")
     public MemberRepository memberRepository() {
         return new MemoryMemberRepository();
     }
+    */
 }

--- a/juwon/core/src/main/java/hello/core/HelloLombok.java
+++ b/juwon/core/src/main/java/hello/core/HelloLombok.java
@@ -1,0 +1,18 @@
+package hello.core;
+
+
+@Getter
+@Setter
+@ToString
+public class HelloLombok {
+
+    private String name;
+    private int age;
+
+    public static void main(String[] args){
+        HelloLombok helloLombok=new HelloLombok();
+        helloLombok.setNmae("asdfas");
+
+        System.out.println("helloLombok="+helloLombok);
+    }
+}

--- a/juwon/core/src/main/java/hello/core/annotation/MainDiscountPolicy.java
+++ b/juwon/core/src/main/java/hello/core/annotation/MainDiscountPolicy.java
@@ -1,0 +1,15 @@
+package hello.core.annotation;
+
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import java.lang.annotation.*;
+
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER,
+        ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Qualifier("mainDiscountPolicy")
+public @interface MainDiscountPolicy {
+}

--- a/juwon/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
+++ b/juwon/core/src/main/java/hello/core/discount/FixDiscountPolicy.java
@@ -3,6 +3,9 @@ package hello.core.discount;
 import hello.core.member.Grade;
 import hello.core.member.Member;
 
+@Component
+//@Qualifier("fixDiscountPolicy")
+@Primary
 public class FixDiscountPolicy implements  DiscountPolicy{
 
     private  int discountFixAmount=1000; //1000원 할인

--- a/juwon/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
+++ b/juwon/core/src/main/java/hello/core/discount/RateDiscountPolicy.java
@@ -1,9 +1,12 @@
 package hello.core.discount;
 
+import hello.core.annotation.MainDiscountPolicy;
 import hello.core.member.Grade;
 import hello.core.member.Member;
 
 @Component
+//@Qualifier("mainDiscountPolicy")
+@MainDiscountPolicy
 public class RateDiscountPolicy implements DiscountPolicy {
     private int discountPercent = 10; //10% 할인
     @Override

--- a/juwon/core/src/main/java/hello/core/order/OrderServiceImpl.java
+++ b/juwon/core/src/main/java/hello/core/order/OrderServiceImpl.java
@@ -1,5 +1,6 @@
 package hello.core.order;
 
+import hello.core.annotation.MainDiscountPolicy;
 import hello.core.discount.DiscountPolicy;
 import hello.core.discount.FixDiscountPolicy;
 import hello.core.discount.RateDiscountPolicy;
@@ -8,19 +9,49 @@ import hello.core.member.MemberRepository;
 import hello.core.member.MemoryMemberRepository;
 
 @Component
+//@RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService{
 
     //DIP 지키고 있다.
     private final MemberRepository memberRepository;
     // private final DiscountPolicy discountPolicy=new FixDiscountPolicy();
     //private final DiscountPolicy discountPolicy = new RateDiscountPolicy();
-    private DiscountPolicy discountPolicy;
+    private final DiscountPolicy discountPolicy;
 
     @Autowired
-    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy){
-        this.memberRepository=memberRepository;
-        this.discountPolicy=discountPolicy;
+    private DiscountPolicy rateDiscountPolicy;
+
+    /**
+    * @Autowired private MemberRepository memberRepository;
+     *@Autowired  private DiscountPolicy discountPolicy;
+    * */
+
+    /**
+    @Autowired
+    public void setMemberRepository(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
     }
+    @Autowired
+    public void setDiscountPolicy(DiscountPolicy discountPolicy) {
+        this.discountPolicy = discountPolicy;
+    }
+     */
+
+    @Autowired
+    public OrderServiceImpl(MemberRepository memberRepository, @MainDiscountPolicy DiscountPolicy rateDiscountPolicy){
+        this.memberRepository=memberRepository;
+        this.discountPolicy=rateDiscountPolicy;.
+    }
+
+    /**
+    @Autowired
+    public void init(MemberRepository memberRepository, DiscountPolicy
+            discountPolicy) {
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
+     */
+
 
     @Override
     public Order createOrder(Long memberId, String itemName, int itemPrice) {
@@ -34,4 +65,14 @@ public class OrderServiceImpl implements OrderService{
     public MemberRepository getMemberRepository() {
         return memberRepository;
     }
+
+    /**
+    @Test
+    void fieldInjectionTest(){
+        OrderServiceImpl orderService=new OrderServiceImpl();
+        orderService.createOrder((1L,"itemA", 10000);
+        orderService.setMemberRepository(new MemoryMemberRepository());
+        orderService.setDiscountPolicy(new FixDiscountPolicy());
+    }
+    */
 }

--- a/juwon/core/src/main/java/hello/core/order/OrderServiceImpleTest.java
+++ b/juwon/core/src/main/java/hello/core/order/OrderServiceImpleTest.java
@@ -1,0 +1,11 @@
+package hello.core.order;
+
+class OrderServiceImpleTest {
+
+    @Test
+    void createOrder() {
+        OrderServiceImpl orderService = new OrderServiceImpl();
+        orderService.createOrder(1L, "itemA", 10000);
+    }
+
+}

--- a/juwon/core/src/test/java/hello/core/autowired/AllBeanTest.java
+++ b/juwon/core/src/test/java/hello/core/autowired/AllBeanTest.java
@@ -1,0 +1,49 @@
+package hello.core.autowired;
+
+import hello.core.AutoAppConfig;
+import hello.core.discount.DiscountPolicy;
+import hello.core.member.Grade;
+import hello.core.member.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class AllBeanTest {
+
+
+    @Test
+    void findAllBean() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class, DiscountService.class);
+
+        DiscountService discountService = ac.getBean(DiscountService.class);
+        Member member = new Member(1L, "userA", Grade.VIP);
+
+        int discountPrice = discountService.discount(member, 10000, "fixDiscountPolicy");
+        assertThat(discountService).isInstanceOf(DiscountService.class);
+        assertThat(discountPrice).isEqualTo(1000);
+    }
+
+    static class DiscountService {
+        private final Map<String, DiscountPolicy> policyMap;
+        private final List<DiscountPolicy> policies;
+
+        @Autowired
+        public DiscountService(Map<String, DiscountPolicy> policyMap, List<DiscountPolicy> policies) {
+            this.policyMap = policyMap;
+            this.policies = policies;
+            System.out.println("policyMap = " + policyMap);
+            System.out.println("policies = " + policies);
+        }
+
+        public int discount(Member member, int price, String discountCode) {
+            DiscountPolicy discountPolicy = policyMap.get(discountCode);
+            System.out.println("discountCode = " + discountCode);
+            System.out.println("discountPolicy = " + discountPolicy);
+            return discountPolicy.discount(member, price);
+        }
+    }
+}

--- a/juwon/core/src/test/java/hello/core/autowired/AutowiredTest.java
+++ b/juwon/core/src/test/java/hello/core/autowired/AutowiredTest.java
@@ -1,0 +1,32 @@
+package hello.core.autowired;
+
+public class AutowiredTest {
+
+    @Test
+    void AutowiredOption(){
+        ApplcationContext ac = new AnnotationConfigApplicationContext(TestBean.class);
+
+
+    }
+
+    static class TestBean{
+
+        //호출 안됨
+        @Autowired(required = false)
+        public void setNoBean1(Member member) {
+            System.out.println("setNoBean1 = " + member);
+        }
+
+        //null 호출
+        @Autowired
+        public void setNoBean2(@Nullable Member member) {
+            System.out.println("setNoBean2 = " + member);
+        }
+
+        //Optional.empty 호출
+        @Autowired(required = false)
+        public void setNoBean3(Optional<Member> member) {
+            System.out.println("setNoBean3 = " + member);
+        }
+    }
+}

--- a/juwon/core/src/test/java/hello/core/scan/AutoAppConfigTest.java
+++ b/juwon/core/src/test/java/hello/core/scan/AutoAppConfigTest.java
@@ -1,7 +1,9 @@
 package hello.core.scan;
 
 import hello.core.AutoAppConfig;
+import hello.core.member.MemberRepository;
 import hello.core.member.MemberService;
+import hello.core.order.OrderServiceImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -14,5 +16,9 @@ public class AutoAppConfigTest {
         ApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class);
         MemberService memberService = ac.getBean(MemberService.class);
         assertThat(memberService).isInstanceOf(MemberService.class);
+
+        OrderServiceImpl bean=ac.getBean(OrderServiceImpl.class);
+        MemberRepository memberRepository=bean.getMemberRepository();
+        System.out.println("memberRepository="+memberRepository);
     }
 }


### PR DESCRIPTION
### 섹션 7 - 의존관계 자동 주입

**편리한 자동 기능을 기본으로 사용하자**
-개발자 입장에서 스프링 빈을 하나 등록할 때 @Component 만 넣어주면 끝나는 일을 @Configuration 설정 정보에 가서 @Bean 을 적고, 객체를 생성하고, 주입할 대상을 일일이 적어주는 과정은 상당히 번거로움
-관리할 빈이 많아서 설정 정보가 커지면 설정 정보를 관리하는 것 자체가 부담
-OCP, DIP

**직접 등록하는 기술 지원 객체는 수동 등록**

**다형성을 적극 활용하는 비즈니스 로직은 수동 등록을 고민해보자**